### PR TITLE
meta descriptionを設定する

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -6,6 +6,7 @@ const Document = () => {
       <Head>
         <meta charSet="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="description" content="1995年生まれの男性が友達と雑談をする" />
         <title>Distortion.fm</title>
         <link rel="icon" href="favicon.png" />
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/purecss@3.0.0/build/pure-min.css"


### PR DESCRIPTION
#17 のSEO対策。headerのmeta属性でdescriptionを設定する。

### 測定結果
https://pagespeed.web.dev/analysis/https-distortionfm-git-meta-description-mtsml-vercel-app/nll0q26b6r?form_factor=mobile
<img width="882" alt="スクリーンショット 2023-09-24 3 17 47" src="https://github.com/mtsml/distortionfm/assets/50922910/efe5f265-b8d9-4f47-aedd-7269ff54d042">