### PR TITLE
feat: add revalidate

### DIFF
--- a/pages/episode/[id].tsx
+++ b/pages/episode/[id].tsx
@@ -285,7 +285,8 @@ export const getStaticProps: GetStaticProps = async (context) => {
         chapters: chapters || [],
         transcripts: transcripts || []
       }
-    }
+    },
+    revalidate: 60 // seconds
   }
 }
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -57,7 +57,7 @@ export const getStaticProps: GetStaticProps = async () => {
     props: {
       episodes
     },
-    revalidate: 60
+    revalidate: 60 // seconds
   }
 }
 

--- a/pages/speaker/[id].tsx
+++ b/pages/speaker/[id].tsx
@@ -106,7 +106,8 @@ export const getStaticProps: GetStaticProps = async (context) => {
     props: {
       episodes,
       speaker
-    }
+    },
+    revalidate: 60 // seconds
   }
 }
 


### PR DESCRIPTION
This pull request includes minor changes to the `getStaticProps` functions in several files to add comments clarifying the revalidation interval.

Clarifications to revalidation interval:

* `pages/episode/[id].tsx`: Added a comment specifying that the revalidation interval is in seconds. ([pages/episode/[id].tsxL288-R289](diffhunk://#diff-36c2a698b9a159bdfd7d4d0b53ada48a8ee9b57a54d4c247b7a915abc206ab7bL288-R289))
* [`pages/index.tsx`](diffhunk://#diff-aa98fd0757d0e1741503c50cfafb7726939d19819638bbe8e030a27adfec34a3L60-R60): Added a comment specifying that the revalidation interval is in seconds.
* `pages/speaker/[id].tsx`: Added a comment specifying that the revalidation interval is in seconds. ([pages/speaker/[id].tsxL109-R110](diffhunk://#diff-8999261d52122f69d2cf59f0772b482a449e406727ff8800de60c7ac6b9e2e44L109-R110))